### PR TITLE
adding CompClub to the constitution

### DIFF
--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -653,7 +653,7 @@ CompClub
 --------
 
 #. CompClub shall be associated with CSESoc.
-#. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $4000.
+#. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $5000.
 #. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.
 
 Insurance

--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -652,7 +652,7 @@ Miscellaneous
 CompClub
 --------
 
-#. CompClub shall be associated with CSESoc.
+#. CompClub will be a branch of CSESoc.
 #. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $5000.
 #. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.
 

--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -756,3 +756,10 @@ Financial year
 
    #. the period of time commencing on the date of incorporation of CSESoc and ending on the following 30 June, and
    #. each period of 12 months after the expiration of the previous financial year of CSESoc, commencing on 1 July and ending on the following 30 June.
+
+CompClub
+--------
+
+#. CompClub shall be associated with CSESoc:
+#. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $4000.
+#. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.

--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -652,7 +652,7 @@ Miscellaneous
 CompClub
 --------
 
-#. CompClub shall be associated with CSESoc:
+#. CompClub shall be associated with CSESoc.
 #. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $4000.
 #. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.
 

--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -652,7 +652,7 @@ Miscellaneous
 CompClub
 --------
 
-#. CompClub will be a branch of CSESoc.
+#. CompClub will be affiliated with CSESoc.
 #. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $5000.
 #. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.
 

--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -649,6 +649,13 @@ Use of technology at general meetings
 Miscellaneous
 =============
 
+CompClub
+--------
+
+#. CompClub shall be associated with CSESoc:
+#. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $4000.
+#. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.
+
 Insurance
 ---------------
 
@@ -756,10 +763,3 @@ Financial year
 
    #. the period of time commencing on the date of incorporation of CSESoc and ending on the following 30 June, and
    #. each period of 12 months after the expiration of the previous financial year of CSESoc, commencing on 1 July and ending on the following 30 June.
-
-CompClub
---------
-
-#. CompClub shall be associated with CSESoc:
-#. CSESoc is responsible for providing the CompClub with reasonable financial funding annually. Unless there are exceptional circumstances, CompClub may request an amount of funding not greater, in any year, less than $4000.
-#. CSESoc must endeavour to retain a Memorandum of Understanding with CompClub outlining an approach to further funding, sponsorship and activities.


### PR DESCRIPTION
- CompClub will remain associated with CSESoc.
- If the School of CSE does not provide CompClub funding, this amendment provides financial certainty for CompClub to continue operating.
- CompClub and CSESoc execs must talk to each other.

Questions:
- Is "further funding, sponsorship and activities" sufficient in the description of the Memorandum of Understanding?
- Is $4000 sufficient for CompClub?