### PR TITLE
adding Stureps to the constitution

### DIFF
--- a/CONSTITUTION.rst
+++ b/CONSTITUTION.rst
@@ -649,6 +649,12 @@ Use of technology at general meetings
 Miscellaneous
 =============
 
+CSE Student Representatives
+---------------------------
+
+#. *Stureps* shall mean the CSE Student Representatives.
+#. CSESoc must endeavour to retain a Memorandum of Understanding with the Stureps outlining an approach to student engagment.
+
 Insurance
 ---------------
 


### PR DESCRIPTION
- Stureps and CSESoc execs must talk to each other.
- Since Stureps lack a platform to communicate with students, this amendment enables Stureps to use CSESoc's platforms for student engagement.